### PR TITLE
Add Pancakes and Filer to Terminus Plugins

### DIFF
--- a/source/_docs/terminus/plugins/directory.md
+++ b/source/_docs/terminus/plugins/directory.md
@@ -96,6 +96,26 @@ The following plugins are supported for Terminus 1.0:
     </div>
   </div>
 </div>
+<div class="row">
+  <div style="margin-bottom:30px;" class="col-md-4">
+    <div class="plugin-dir">
+      <div class="terminus-plugin">
+        <h3>Pancakes</h3>
+        <p class="topic-info__description">Author: <a href="https://github.com/derimagia">Dave Wikoff</a></p>
+        <p class="topic-info__description">Open Pantheon Site Databases in your Favorite SQL GUI Client.</p>
+        <a href="https://github.com/terminus-plugin-project/terminus-pancakes" class="btn-primary btn get-plugin">Get Plugin</a>
+      </div>
+    </div>
+    <div class="plugin-dir">
+      <div class="terminus-plugin">
+        <h3>Filer</h3>
+        <p class="topic-info__description">Author: <a href="https://github.com/sean-e-dietrich">Sean Dietrich</a></p>
+        <p class="topic-info__description">Open SFTP Connections to your Pantheon Sites.</p>
+        <a href="https://github.com/terminus-plugin-project/terminus-filer-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="terminus-pager">
   <hr>
   <a style="float:left;" href="/docs/terminus/plugins"><span class="terminus-pager-lsaquo">&lsaquo;</span>Manage Plugins</a>


### PR DESCRIPTION
Closes #2069

## Effect
PR includes the following changes:
- Add Pancakes and Filer to Terminus Plugins

May want to somehow denote them as being third party some other way except removing the badge.
